### PR TITLE
Filter markets by commodity input percentage threshold

### DIFF
--- a/app/Livewire/Dashboard/Index.php
+++ b/app/Livewire/Dashboard/Index.php
@@ -47,14 +47,16 @@ class Index extends Component
             // Hitung persentase komoditas yang diinputkan
             $persentaseInput = ($komoditasInput / $totalKomoditas) * 100;
             
-            // Masukkan semua pasar ke dalam list untuk ditampilkan di modal
-            $cekkomoditas[] = [
-                'pasar_id' => $p->id,
-                'pasar_name' => $p->namapasar, // Ganti dengan atribut nama pasar yang sesuai
-                'komoditas_input' => $komoditasInput,
-                'persentase_input' => number_format($persentaseInput, 2),
-                'total_komoditas' => $totalKomoditas,
-            ];
+            // Cek apakah persentase input kurang dari atau sama dengan 75%
+            if ($persentaseInput <= 75) {
+                $cekkomoditas[] = [
+                    'pasar_id' => $p->id,
+                    'pasar_name' => $p->namapasar, // Ganti dengan atribut nama pasar yang sesuai
+                    'komoditas_input' => $komoditasInput,
+                    'persentase_input' => number_format($persentaseInput, 2),
+                    'total_komoditas' => $totalKomoditas,
+                ];
+            }
         }
 
         // Tampilkan pasar yang belum menginputkan data lebih dari 50%


### PR DESCRIPTION
## Summary
Updated the dashboard index logic to filter markets based on commodity input completion percentage, only displaying markets that have 75% or less commodity data input.

## Key Changes
- Added a conditional check to filter markets by commodity input percentage
- Markets are now only added to the `$cekkomoditas` list if their input percentage is ≤ 75%
- This prevents markets with higher completion rates from appearing in the incomplete data list

## Implementation Details
The change wraps the market data collection in an `if ($persentaseInput <= 75)` condition. This ensures that only markets with incomplete commodity input (75% or less) are included in the results displayed to users, helping focus attention on markets that still need to complete their data entry.

https://claude.ai/code/session_017fM45KhdXr77F2M6qQ1ZbK